### PR TITLE
Upload pit scouting robot images to S3

### DIFF
--- a/.github/workflows/superalliance-ui-workflow.yml
+++ b/.github/workflows/superalliance-ui-workflow.yml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Deploy
-        uses: reggionick/s3-deploy@v3
+        uses: reggionick/s3-deploy@v4
         with:
           folder: app/dist
           bucket: ${{ secrets.S3_BUCKET }}
@@ -54,5 +54,6 @@ jobs:
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
           invalidation: /
           delete-removed: true
-          no-cache: true
+          # Browser cache for 20 minutes, CloudFront cache for 24 hours since we manually invalidate on deploy
+          cache-control: 'public, max-age=1200, s-maxage=86400, must-revalidate'
           private: true

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ The workflow for deploying the API is defined in `superalliance-api-workflow.yml
         * `npm update`
         * `npm install`
     * Create a file named `.env.local` and put the following configuration values in it:
-        * VITE_CLERK_PUBLISHABLE_KEY=<get_value_from_admin>
-        * VITE_API_URL=<get_value_from_admin>
+        ```
+        VITE_CLERK_PUBLISHABLE_KEY=<get_value_from_admin>
+        VITE_API_URL=<get_value_from_admin>
+        ```
     * `npm run dev` to start the application
 
 3. Set up the API application
@@ -33,14 +35,16 @@ The workflow for deploying the API is defined in `superalliance-api-workflow.yml
         * `npm install`
         * `npm install -g nodemon`
     * Create a file named `.env` and put the following configuration values in it:
-        * TBA_KEY=<get_value_from_admin>
-        * MONGODB_URI=<get_value_from_admin>
-        * CLERK_PUBLISHABLE_KEY=<get_value_from_admin>
-        * CLERK_SECRET_KEY=<get_value_from_admin>
-        * ROBOT_IMAGE_DISTRO=robot-images.stmarobotics.org
-        * AWS_REGION=us-east-2
+        ```
+        TBA_KEY=<get_value_from_admin>
+        MONGODB_URI=<get_value_from_admin>
+        CLERK_PUBLISHABLE_KEY=<get_value_from_admin>
+        CLERK_SECRET_KEY=<get_value_from_admin>
+        ROBOT_IMAGE_DISTRO=robot-images.stmarobotics.org
+        AWS_REGION=us-east-2
+        ```
     * In order to upload pit forms with images:
-      1) log in to the [AWS access portal](https://d-9067879019.awsapps.com/start) with your stmarobotics.org Google account
+      1) Log in to the [AWS access portal](https://d-9067879019.awsapps.com/start) with your stmarobotics.org Google account
       2) Choose _Access keys_
       3) Configure your access keys with an environment variable or credentials file
     * `npm run dev` to start the application

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The workflow for deploying the API is defined in `superalliance-api-workflow.yml
         * `npm install`
     * Create a file named `.env.local` and put the following configuration values in it:
         * VITE_CLERK_PUBLISHABLE_KEY=<get_value_from_admin>
-        * CLERK_SECRET_KEY=<get_value_from_admin>
         * VITE_API_URL=<get_value_from_admin>
     * `npm run dev` to start the application
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ The workflow for deploying the API is defined in `superalliance-api-workflow.yml
     * Create a file named `.env` and put the following configuration values in it:
         * TBA_KEY=<get_value_from_admin>
         * MONGODB_URI=<get_value_from_admin>
-        * API_URL="http://localhost:3000"
+        * CLERK_PUBLISHABLE_KEY
+        * CLERK_SECRET_KEY
+        * API_URL=http://localhost:3000
+        * ROBOT_IMAGE_DISTRO=robot-images.stmarobotics.org
+        * AWS_REGION=us-east-2
+    * In order to upload pit forms with images:
+      1) log in to the [AWS access portal](https://d-9067879019.awsapps.com/start) with your stmarobotics.org Google account
+      2) Choose _Access keys_
+      3) Configure your access keys with an environment variable or credentials file
     * `npm run dev` to start the application
 
 ## Helper Scripts 

--- a/api/package.json
+++ b/api/package.json
@@ -12,6 +12,8 @@
   "license": "ISC",
   "dependencies": {
     "@clerk/express": "^1.4.19",
+    "@aws-sdk/client-s3": "^3.812.0",
+    "@aws-sdk/s3-request-presigner": "^3.812.0",
     "aws-serverless-express": "^3.4.0",
     "axios": "^1.9.0",
     "body-parser": "^1.20.2",

--- a/api/routes/pitFormRouter.js
+++ b/api/routes/pitFormRouter.js
@@ -85,6 +85,4 @@ pitFormRouter.post("/api/form/pit/image-upload", requireAuth(), async (req, res)
   }
 });
 
-// ...existing code...
-
 module.exports = pitFormRouter;

--- a/api/routes/pitFormRouter.js
+++ b/api/routes/pitFormRouter.js
@@ -74,6 +74,7 @@ pitFormRouter.post("/api/form/pit/image-upload", requireAuth(), async (req, res)
     Bucket: bucket,
     Key: key,
     ContentType: fileType,
+    CacheControl: "public, max-age=31536000, immutable", // file name is unique, content will never change
   });
 
   try {

--- a/api/routes/pitFormRouter.js
+++ b/api/routes/pitFormRouter.js
@@ -1,4 +1,6 @@
 const { Router } = require("express");
+const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
+const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 
 const pitFormRouter = Router();
 
@@ -31,6 +33,13 @@ pitFormRouter.post("/api/form/pit/submit", requireAuth(), async (req, res) => {
     robotRating: data.robotRating,
   });
 
+  const exists = await PitFormSchema.exists({
+    teamNumber: sendForm.teamNumber,
+    event: sendForm.event,
+  });
+
+  if (exists) return res.status(400).json({ error: "Pit form already exists for this team and event" });
+
   await sendForm.save().catch((err) => {
     return res.status(500).send(err);
   });
@@ -45,8 +54,37 @@ pitFormRouter.get("/api/form/pit/:eventCode/:teamNumber", requireAuth(), async (
     teamNumber: teamNumber,
     event: eventCode,
   }).catch((err) => null);
-  if (!data) return res.status(404).json({ error: "Form not found" });
-  return res.send(data[0]);
+  if (!data || data.length == 0) return res.status(404).json({ error: "Form not found" });
+  return res.json(data[0]);
 });
+
+// Create a signed URL for uploading robot pit images to S3
+pitFormRouter.post("/api/form/pit/image-upload", requireAuth(), async (req, res) => {
+  const { year, teamNumber, eventCode, fileType } = req.body;
+  if (!year || !teamNumber || !eventCode || !fileType) {
+    return res.status(400).json({ error: "year, teamNumber, eventCode, and fileType are required" });
+  }
+
+  const s3 = new S3Client({ region: process.env.AWS_REGION });
+  const bucket = process.env.ROBOT_IMAGE_BUCKET;
+  const extension = fileType.split("/")[1];
+  const key = `${year}/${eventCode}/${teamNumber}_${Date.now()}.${extension}`;
+
+  const command = new PutObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    ContentType: fileType,
+  });
+
+  try {
+    const url = await getSignedUrl(s3, command, { expiresIn: 300 }); // 5 minutes
+    const fileUrl = `https://${process.env.ROBOT_IMAGE_DISTRO}/${key}`;
+    return res.json({ url, fileUrl, key });
+  } catch (err) {
+    return res.status(500).json({ error: "Failed to generate signed URL" });
+  }
+});
+
+// ...existing code...
 
 module.exports = pitFormRouter;

--- a/app/src/pages/forms/Pit.tsx
+++ b/app/src/pages/forms/Pit.tsx
@@ -100,7 +100,7 @@ export default function PitForm() {
       if (!file) return toast.error("Please upload an image!");
 
       // Get signed S3 URL from backend
-      const { data: s3Data } = await axios.post(
+      const { data: s3Data } = await api.post(
         `${import.meta.env.VITE_API_URL}/api/form/pit/image-upload`,
         {
           "year": appConfig?.year,
@@ -114,6 +114,7 @@ export default function PitForm() {
       await axios.put(s3Data.url, file, {
         headers: {
           "Content-Type": file.type,
+          "Cache-Control": "public, max-age=31536000, immutable"
         },
       });
 


### PR DESCRIPTION
This uses a presigned URL to upload images to an S3 bucket instead of a third party image sharing service.

There was some setup in AWS:
- Created a new S3 bucket
  - Configured a lifecycle rule to delete images from S3 after 18-months
  - Configured CORS on the S3 bucket
- Created a CloudFront distribution for the new bucket
- Granted our lambda write access to the new bucket (so it can create signed URLs)
- Added environment variables to the repo for the bucket name and distribution URL

This also fixes a bug where a scouter could submit duplicate pit forms for the same team at the same event. There was some code on the frontend to look for a duplicate, but the backend wasn't properly returning 404 when there was no form, and the frontend wasn't handling 404. I fixed the front and backend for the existing check, and I added a check on the backend when a form is submitted.

Resolves #30 