### PR TITLE
Alliance selection enhancements and bug fixes

### DIFF
--- a/api/models/TeamSelectionSchema.js
+++ b/api/models/TeamSelectionSchema.js
@@ -3,9 +3,21 @@ const { Schema, model } = require("mongoose");
 const TeamSelectionSchema = new Schema(
   {
     _id: Schema.Types.ObjectId,
+    eventCode: {
+      type: String, 
+      required: true,
+      index: true
+    },
+    userId: {
+      type: String,
+      required: true
+    },
     teams: Array,
   },
   { timestamps: true }
 );
+
+// Index for efficient queries - get latest by eventCode
+TeamSelectionSchema.index({ eventCode: 1, updatedAt: -1 });
 
 module.exports = model("TeamSelection", TeamSelectionSchema, "teamSelection");

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -987,13 +987,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.5.tgz",
-      "integrity": "sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.11.tgz",
+      "integrity": "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "fast-xml-parser": "5.3.6",
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2526,9 +2526,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4094,10 +4094,10 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -4106,6 +4106,22 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -5670,9 +5686,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5880,9 +5896,9 @@
       }
     },
     "node_modules/nodemon/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6093,6 +6109,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -6787,9 +6818,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
       "funding": [
         {
           "type": "github",

--- a/api/routes/teamSelectionRouter.js
+++ b/api/routes/teamSelectionRouter.js
@@ -6,41 +6,135 @@ const TeamSelectionSchema = require("../models/TeamSelectionSchema");
 const mongoose = require("mongoose");
 const { requireAuth, getAuth } = require("@clerk/express");
 
-teamSelectionRouter.post("/api/teamSelection/save", requireAuth(), async (req, res) => {
-  const userRole = getAuth(req).sessionClaims?.data?.role;
+teamSelectionRouter.post("/api/teamSelection/save/:eventCode", requireAuth(), async (req, res) => {
+  const auth = getAuth(req);
+  const userRole = auth.sessionClaims?.data?.role;
 
   if (userRole !== "admin") {
     return res.status(403).json({ error: "Forbidden: Admins only" });
   }
-  const data = req.body;
+  
+  const { eventCode } = req.params;
+  const { teams } = req.body;
+  const userId = auth.userId || "Unknown";
 
-  const currSelection = await TeamSelectionSchema.findOne({});
-
-  if (!currSelection) {
-    const sendSelection = await new TeamSelectionSchema({
+  try {
+    const newSelection = new TeamSelectionSchema({
       _id: new mongoose.Types.ObjectId(),
-      teams: data.teams,
+      eventCode,
+      userId,
+      teams
     });
 
-    await sendSelection.save().catch((err) => {
-      return res.status(500).send(err);
-    });
-  } else {
-    await TeamSelectionSchema.findOneAndReplace({}, data);
+    await newSelection.save();
+    return res.send("Submitted Team Selection!");
+  } catch (err) {
+    return res.status(500).send(err);
   }
-
-  return res.send("Submitted Team Selection!");
 });
 
-teamSelectionRouter.get("/api/teamSelection", requireAuth(), async (req, res) => {
-  const userRole = getAuth(req).sessionClaims?.data?.role;
+teamSelectionRouter.get("/api/teamSelection/:eventCode", requireAuth(), async (req, res) => {
+  const auth = getAuth(req);
+  const userRole = auth.sessionClaims?.data?.role;
 
   if (userRole !== "admin") {
     return res.status(403).json({ error: "Forbidden: Admins only" });
   }
-  const selection = await TeamSelectionSchema.findOne({});
+  
+  const { eventCode } = req.params;
+  
+  // Get the latest selection for this event
+  const selection = await TeamSelectionSchema
+    .findOne({ eventCode })
+    .sort({ updatedAt: -1 }); // Latest first
+    
   if (!selection) return res.send({});
   return res.send(selection);
+});
+
+teamSelectionRouter.get("/api/teamSelection/:eventCode/report", requireAuth(), async (req, res) => {
+  const auth = getAuth(req);
+  const userRole = auth.sessionClaims?.data?.role;
+
+  if (userRole !== "admin") {
+    return res.status(403).json({ error: "Forbidden: Admins only" });
+  }
+
+  const { eventCode } = req.params;
+  
+  try {
+    // Get the latest selection for this event
+    const selection = await TeamSelectionSchema
+      .findOne({ eventCode })
+      .sort({ updatedAt: -1 });
+      
+    if (!selection) {
+      return res.status(404).json({ error: "No team selection found for this event" });
+    }
+
+    // Group teams by column
+    const teamsByColumn = {
+      unsorted: [],
+      r1: [],
+      r2: [],
+      r3: []
+    };
+
+    selection.teams.forEach(team => {
+      if (teamsByColumn[team.columnId]) {
+        teamsByColumn[team.columnId].push(team);
+      }
+    });
+
+    // Generate CSV content
+    const includeUnsorted = teamsByColumn.unsorted.length > 0;
+    
+    const maxRows = Math.max(
+      includeUnsorted ? teamsByColumn.unsorted.length : 0,
+      teamsByColumn.r1.length,
+      teamsByColumn.r2.length,
+      teamsByColumn.r3.length
+    );
+
+    // Build header row conditionally
+    const headers = [];
+    if (includeUnsorted) headers.push(`Unsorted (${teamsByColumn.unsorted.length})`);
+    headers.push(`R1 (${teamsByColumn.r1.length})`);
+    headers.push(`R2 (${teamsByColumn.r2.length})`);
+    headers.push(`R3 (${teamsByColumn.r3.length})`);
+    
+    let csvContent = headers.join(',') + '\n';
+    
+    for (let i = 0; i < maxRows; i++) {
+      const row = [];
+      if (includeUnsorted) {
+        row.push(teamsByColumn.unsorted[i] ? `${teamsByColumn.unsorted[i].teamNumber} - ${teamsByColumn.unsorted[i].teamName}` : '');
+      }
+      row.push(teamsByColumn.r1[i] ? `${teamsByColumn.r1[i].teamNumber} - ${teamsByColumn.r1[i].teamName}` : '');
+      row.push(teamsByColumn.r2[i] ? `${teamsByColumn.r2[i].teamNumber} - ${teamsByColumn.r2[i].teamName}` : '');
+      row.push(teamsByColumn.r3[i] ? `${teamsByColumn.r3[i].teamNumber} - ${teamsByColumn.r3[i].teamName}` : '');
+      
+      // Escape commas and quotes in CSV
+      const escapedRow = row.map(cell => {
+        if (cell.includes(',') || cell.includes('"') || cell.includes('\n')) {
+          return `"${cell.replace(/"/g, '""')}"`;
+        }
+        return cell;
+      });
+      
+      csvContent += escapedRow.join(',') + '\n';
+    }
+
+    // Set appropriate headers for CSV download
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', `attachment; filename="team-selection-${eventCode}-${new Date().toISOString().split('T')[0]}.csv"`);
+    
+    return res.send(csvContent);
+    
+  } catch (err) {
+    console.error('Error generating report:', err);
+    return res.status(500).json({ error: "Failed to generate report" });
+  }
 });
 
 module.exports = teamSelectionRouter;

--- a/api/routes/teamSelectionRouter.js
+++ b/api/routes/teamSelectionRouter.js
@@ -29,7 +29,8 @@ teamSelectionRouter.post("/api/teamSelection/save/:eventCode", requireAuth(), as
     await newSelection.save();
     return res.send("Submitted Team Selection!");
   } catch (err) {
-    return res.status(500).send(err);
+    console.error("Error saving team selection:", err);
+    return res.status(500).json({ error: "Failed to save team selection" });
   }
 });
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -2368,9 +2368,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2452,9 +2452,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4293,9 +4293,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.58.0.tgz",
-      "integrity": "sha512-mr0tmS/4FoVk1cnaeN244A/wjvGDNItZKR8hRhnmCzygyRXYtKF5jVDSIILR1U97CTzAYmbgIj/Dukg62ggG5w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -4307,9 +4307,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.58.0.tgz",
-      "integrity": "sha512-+s++dbp+/RTte62mQD9wLSbiMTV+xr/PeRJEc/sFZFSBRlHPNPVaf5FXlzAL77Mr8FtSfQqCN+I598M8U41ccQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -4321,9 +4321,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.58.0.tgz",
-      "integrity": "sha512-MFWBwTcYs0jZbINQBXHfSrpSQJq3IUOakcKPzfeSznONop14Pxuqa0Kg19GD0rNBMPQI2tFtu3UzapZpH0Uc1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -4335,9 +4335,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.58.0.tgz",
-      "integrity": "sha512-yiKJY7pj9c9JwzuKYLFaDZw5gma3fI9bkPEIyofvVfsPqjCWPglSHdpdwXpKGvDeYDms3Qal8qGMEHZ1M/4Udg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -4349,9 +4349,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.58.0.tgz",
-      "integrity": "sha512-x97kCoBh5MOevpn/CNK9W1x8BEzO238541BGWBc315uOlN0AD/ifZ1msg+ZQB05Ux+VF6EcYqpiagfLJ8U3LvQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -4363,9 +4363,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.58.0.tgz",
-      "integrity": "sha512-Aa8jPoZ6IQAG2eIrcXPpjRcMjROMFxCt1UYPZZtCxRV68WkuSigYtQ/7Zwrcr2IvtNJo7T2JfDXyMLxq5L4Jlg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -4377,9 +4377,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.58.0.tgz",
-      "integrity": "sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -4391,9 +4391,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.58.0.tgz",
-      "integrity": "sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -4405,9 +4405,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.58.0.tgz",
-      "integrity": "sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -4419,9 +4419,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.58.0.tgz",
-      "integrity": "sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -4433,9 +4433,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.58.0.tgz",
-      "integrity": "sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -4447,9 +4447,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.58.0.tgz",
-      "integrity": "sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -4461,9 +4461,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.58.0.tgz",
-      "integrity": "sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
@@ -4475,9 +4475,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.58.0.tgz",
-      "integrity": "sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -4489,9 +4489,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.58.0.tgz",
-      "integrity": "sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -4503,9 +4503,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.58.0.tgz",
-      "integrity": "sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -4517,9 +4517,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.58.0.tgz",
-      "integrity": "sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -4531,9 +4531,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.58.0.tgz",
-      "integrity": "sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -4545,9 +4545,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.58.0.tgz",
-      "integrity": "sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -4559,9 +4559,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.58.0.tgz",
-      "integrity": "sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -4573,9 +4573,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.58.0.tgz",
-      "integrity": "sha512-fd/zpJniln4ICdPkjWFhZYeY/bpnaN9pGa6ko+5WD38I0tTqk9lXMgXZg09MNdhpARngmxiCg0B0XUamNw/5BQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -4587,9 +4587,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.58.0.tgz",
-      "integrity": "sha512-YpG8dUOip7DCz3nr/JUfPbIUo+2d/dy++5bFzgi4ugOGBIox+qMbbqt/JoORwvI/C9Kn2tz6+Bieoqd5+B1CjA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -4601,9 +4601,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.58.0.tgz",
-      "integrity": "sha512-b9DI8jpFQVh4hIXFr0/+N/TzLdpBIoPzjt0Rt4xJbW3mzguV3mduR9cNgiuFcuL/TeORejJhCWiAXe3E/6PxWA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -4615,9 +4615,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.58.0.tgz",
-      "integrity": "sha512-CSrVpmoRJFN06LL9xhkitkwUcTZtIotYAF5p6XOR2zW0Zz5mzb3IPpcoPhB02frzMHFNo1reQ9xSF5fFm3hUsQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -4629,9 +4629,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.58.0.tgz",
-      "integrity": "sha512-QFsBgQNTnh5K0t/sBsjJLq24YVqEIVkGpfN2VHsnN90soZyhaiA9UUHufcctVNL4ypJY0wrwad0wslx2KJQ1/w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -7516,9 +7516,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7580,9 +7580,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7667,9 +7667,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7778,9 +7778,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7981,9 +7981,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8038,9 +8038,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -8370,9 +8370,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9814,13 +9814,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -11081,9 +11081,9 @@
       "license": "Unlicense"
     },
     "node_modules/rollup": {
-      "version": "4.58.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.58.0.tgz",
-      "integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11097,31 +11097,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.58.0",
-        "@rollup/rollup-android-arm64": "4.58.0",
-        "@rollup/rollup-darwin-arm64": "4.58.0",
-        "@rollup/rollup-darwin-x64": "4.58.0",
-        "@rollup/rollup-freebsd-arm64": "4.58.0",
-        "@rollup/rollup-freebsd-x64": "4.58.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.58.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.58.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.58.0",
-        "@rollup/rollup-linux-arm64-musl": "4.58.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.58.0",
-        "@rollup/rollup-linux-loong64-musl": "4.58.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.58.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.58.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.58.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.58.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.58.0",
-        "@rollup/rollup-linux-x64-gnu": "4.58.0",
-        "@rollup/rollup-linux-x64-musl": "4.58.0",
-        "@rollup/rollup-openbsd-x64": "4.58.0",
-        "@rollup/rollup-openharmony-arm64": "4.58.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.58.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.58.0",
-        "@rollup/rollup-win32-x64-gnu": "4.58.0",
-        "@rollup/rollup-win32-x64-msvc": "4.58.0",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -13035,9 +13035,9 @@
       }
     },
     "node_modules/workbox-build/node_modules/rollup": {
-      "version": "2.79.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/app/src/components/admin/admin-settings.tsx
+++ b/app/src/components/admin/admin-settings.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { useSuperAlliance } from "@/contexts/SuperAllianceProvider";
 import { useSuperAllianceApi } from "@/lib/superallianceapi";
+import { useEffect } from "react";
 
 const adminSettingsSchema = z.object({
   event: z.string({
@@ -43,14 +44,22 @@ function AdminSettingsForm({
   events: any;
   settings: Partial<SettingsFormValues>;
 }) {
+  const { setSelectedEvent, selectedEvent } = useSuperAlliance();
+  const { api } = useSuperAllianceApi();
+
   const form = useForm<SettingsFormValues>({
     resolver: zodResolver(adminSettingsSchema),
-    defaultValues: Object.keys(settings).length > 0 ? settings : defaultValues,
+    defaultValues: {
+      event: selectedEvent || (Object.keys(settings).length > 0 ? settings.event : defaultValues.event) || "none",
+    },
     mode: "onChange",
   });
 
-  const { setSelectedEvent } = useSuperAlliance();
-  const { api } = useSuperAllianceApi();
+  useEffect(() => {
+    if (selectedEvent) {
+      form.setValue("event", selectedEvent);
+    }
+  }, [selectedEvent, form]);
 
   function onSubmit(data: SettingsFormValues) {
     (async function () {

--- a/app/src/components/selection/selection-column.tsx
+++ b/app/src/components/selection/selection-column.tsx
@@ -25,7 +25,6 @@ interface BoardColumnProps {
   isOverlay?: boolean;
   totalTeamCount: number;
   setSelectedTeam?: (teamId: UniqueIdentifier) => void;
-  printMode?: boolean;
   compareMode?: boolean;
   leftTeam?: UniqueIdentifier;
   rightTeam?: UniqueIdentifier;
@@ -39,7 +38,6 @@ export function BoardColumn({
   isOverlay,
   totalTeamCount,
   setSelectedTeam,
-  printMode,
   compareMode,
   leftTeam,
   rightTeam,
@@ -67,9 +65,7 @@ export function BoardColumn({
   };
 
   const variants = cva(
-    `${
-      printMode ? "" : "h-[66vh] max-h-[66vh]"
-    } md:w-[22vw] w-[250px] min-w-[150px] max-w-full bg-primary-foreground flex flex-col shrink-0 snap-center`,
+    "h-[66vh] max-h-[66vh] md:w-[22vw] w-[250px] min-w-[150px] max-w-full bg-primary-foreground flex flex-col shrink-0 snap-center",
     {
       variants: {
         dragging: {
@@ -98,9 +94,7 @@ export function BoardColumn({
       </CardHeader>
       <ScrollArea>
         <CardContent
-          className={`flex grow flex-col gap-2 p-2 ${
-            printMode ? "mb-10" : ""
-          }`}
+          className={`flex grow flex-col gap-2 p-2`}
         >
           <SortableContext items={teamsIds}>
             {teams.map((team) => {
@@ -109,7 +103,6 @@ export function BoardColumn({
                   key={team.id}
                   team={team}
                   setSelectedTeam={setSelectedTeam!}
-                  printMode={printMode}
                   compareMode={compareMode}
                   leftTeam={leftTeam}
                   rightTeam={rightTeam}
@@ -127,10 +120,8 @@ export function BoardColumn({
 
 export function BoardContainer({
   children,
-  printMode,
 }: {
   children: React.ReactNode;
-  printMode: boolean;
 }) {
   const dndContext = useDndContext();
 
@@ -150,11 +141,7 @@ export function BoardContainer({
       })}
     >
       <div
-        className={`flex gap-4 ${
-          printMode
-            ? "items-start flex-row"
-            : "items-center flex-col md:flex-row"
-        } justify-center`}
+        className={"flex gap-4 items-center flex-col md:flex-row justify-center"}
       >
         {children}
       </div>

--- a/app/src/components/selection/selection-column.tsx
+++ b/app/src/components/selection/selection-column.tsx
@@ -5,7 +5,15 @@ import { useMemo } from "react";
 import { Team, TeamCard } from "@/components/selection/selection-team-card";
 import { cva } from "class-variance-authority";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { IconListNumbers, IconHash } from "@tabler/icons-react";
 
 export interface Column {
   id: UniqueIdentifier;
@@ -24,6 +32,8 @@ interface BoardColumnProps {
   teams: Team[];
   isOverlay?: boolean;
   totalTeamCount: number;
+  onSortByNumber?: () => void;
+  onSortByRank?: () => void;
   setSelectedTeam?: (teamId: UniqueIdentifier) => void;
   compareMode?: boolean;
   leftTeam?: UniqueIdentifier;
@@ -37,6 +47,8 @@ export function BoardColumn({
   teams,
   isOverlay,
   totalTeamCount,
+  onSortByNumber,
+  onSortByRank,
   setSelectedTeam,
   compareMode,
   leftTeam,
@@ -85,12 +97,50 @@ export function BoardColumn({
         dragging: isOverlay ? "overlay" : isDragging ? "over" : undefined,
       })}
     >
-      <CardHeader className="p-4 font-semibold border-b-2 text-center flex flex-row space-between items-center">
-        <span className="m-auto">
-          {column.id == "r3" && totalTeamCount - 23 > 0
-            ? `${column.title} (${teams.length}/${totalTeamCount - 23})`
-            : `${column.title} (${teams.length})`}
-        </span>
+      <CardHeader className="border-b-2 p-4">
+        <div className="flex items-center gap-2 font-semibold">
+          <span className="flex-1 text-center">
+              {column.id == "r3" && totalTeamCount - 23 > 0
+                ? `${column.title} (${teams.length}/${totalTeamCount - 23})`
+                : `${column.title} (${teams.length})`}
+          </span>
+          {column.id === "unsorted" && !isOverlay && (
+            <TooltipProvider delayDuration={0}>
+              <div className="ml-auto flex items-center gap-1">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={onSortByNumber}
+                      aria-label="Sort by team number"
+                    >
+                      <IconHash className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Sort by team number</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={onSortByRank}
+                      aria-label="Sort by rank"
+                    >
+                      <IconListNumbers className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Sort by rank</TooltipContent>
+                </Tooltip>
+              </div>
+            </TooltipProvider>
+          )}
+        </div>
       </CardHeader>
       <ScrollArea>
         <CardContent

--- a/app/src/components/selection/selection-compare-view.tsx
+++ b/app/src/components/selection/selection-compare-view.tsx
@@ -24,6 +24,7 @@ const SelectionCompareView = ({
   statsDifference,
   side,
   opr,
+  moveTeamToColumn,
 }: {
   aggregation: any;
   pitForm: any;
@@ -31,6 +32,7 @@ const SelectionCompareView = ({
   statsDifference: any;
   side: any;
   opr: any;
+  moveTeamToColumn?: (teamId: string, columnId: string) => void;
 }) => {
   const averages = [
     {
@@ -155,6 +157,17 @@ const SelectionCompareView = ({
       statKey: "defendedAgainstPercentage",
     },
   ];
+
+  const handleMoveTeam = (columnId: string) => {
+    if (moveTeamToColumn && aggregation?._id) {
+      moveTeamToColumn(aggregation._id.toString(), columnId);
+      toast.success(`Team ${aggregation._id} moved to ${columnId.toUpperCase()}`);
+    }
+  };
+
+  const currentTeam = teams?.find((team: any) => team.id === aggregation?._id?.toString());
+  const currentColumnId = currentTeam?.columnId;
+
   return (
     <div className="flex flex-col justify-center items-center gap-4">
       <h2 className="text-3xl font-bold tracking-tight">
@@ -165,11 +178,42 @@ const SelectionCompareView = ({
         }
       </h2>
       <Tabs defaultValue="inspector" className="space-y-4 w-full h-full">
-        <TabsList>
-          <TabsTrigger value="inspector">Inspector</TabsTrigger>
-          <TabsTrigger value="pitform">Pit Form</TabsTrigger>
-          <TabsTrigger value="graphs">Graphs</TabsTrigger>
-        </TabsList>
+        <div className="flex justify-between items-center">
+          <TabsList>
+            <TabsTrigger value="inspector">Inspector</TabsTrigger>
+            <TabsTrigger value="pitform">Pit Form</TabsTrigger>
+            <TabsTrigger value="graphs">Graphs</TabsTrigger>
+          </TabsList>
+          
+          {moveTeamToColumn && (
+            <div className="flex items-center gap-2">
+              <Button
+                onClick={() => handleMoveTeam('r1')}
+                variant={currentColumnId === 'r1' ? "default" : "outline"}
+                size="sm"
+                className="h-8"
+              >
+                R1
+              </Button>
+              <Button
+                onClick={() => handleMoveTeam('r2')}
+                variant={currentColumnId === 'r2' ? "default" : "outline"}
+                size="sm"
+                className="h-8"
+              >
+                R2
+              </Button>
+              <Button
+                onClick={() => handleMoveTeam('r3')}
+                variant={currentColumnId === 'r3' ? "default" : "outline"}
+                size="sm"
+                className="h-8"
+              >
+                R3
+              </Button>
+            </div>
+          )}
+        </div>
         <TabsContent value="inspector" className="space-y-4">
           <div>
             <div className="grid gap-4 grid-cols-2">

--- a/app/src/components/selection/selection-compare.tsx
+++ b/app/src/components/selection/selection-compare.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { useSuperAllianceApi } from "@/lib/superallianceapi";
 import SelectionCompareView from "./selection-compare-view";
 import { useSuperAlliance } from "@/contexts/SuperAllianceProvider";
+import { Button } from "@/components/ui/button";
 
 const round = (num: number, digits: number = 1) => {
   const factor = 100 ** digits;
@@ -18,6 +19,7 @@ const SelectionCompare = ({
   rightTeam,
   setLeftTeam,
   setRightTeam,
+  moveTeamToColumn,
 }: {
   compareMode?: boolean;
   setCompareMode: (compareMode: boolean) => void;
@@ -27,6 +29,7 @@ const SelectionCompare = ({
   rightTeam: any;
   setLeftTeam: (leftTeam: any) => void;
   setRightTeam: (rightTeam: any) => void;
+  moveTeamToColumn?: (teamId: string, columnId: string) => void;
 }) => {
   const [compareData, setCompareData] = useState<any>();
   const [pitFormData, setPitFormData] = useState<any>();
@@ -127,7 +130,7 @@ const SelectionCompare = ({
         }}
         title="Team Comparison"
         fullScreen
-        withCloseButton={true}
+        withCloseButton={false}
         zIndex={1000}
         radius={"lg"}
         styles={{
@@ -136,6 +139,20 @@ const SelectionCompare = ({
           },
         }}
       >
+        <div className="flex justify-end mb-4">
+          <Button
+            onClick={() => {
+              setLeftTeam(null);
+              setRightTeam(null);
+              setCompareData(null);
+              setPitFormData(null);
+              setStatsDifference(null);
+              setCompareMode(false);
+            }}
+          >
+            Close
+          </Button>
+        </div>
         <div className="flex flex-row py-2 w-full">
           <div className="w-[50%] px-4">
             {compareData?.left && statsDifference && (
@@ -147,6 +164,7 @@ const SelectionCompare = ({
                   statsDifference={statsDifference.left}
                   side={"left"}
                   opr={opr?.left}
+                  moveTeamToColumn={moveTeamToColumn}
                 />
               </>
             )}
@@ -161,6 +179,7 @@ const SelectionCompare = ({
                   statsDifference={statsDifference.right}
                   side={"right"}
                   opr={opr?.right}
+                  moveTeamToColumn={moveTeamToColumn}
                 />
               </>
             )}

--- a/app/src/components/selection/selection-dnd.tsx
+++ b/app/src/components/selection/selection-dnd.tsx
@@ -23,8 +23,9 @@ import { SortableContext, arrayMove } from "@dnd-kit/sortable";
 import { hasDraggableData } from "@/components/selection/selection-utils";
 import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/button";
-import { Diff, Download, Printer, Save } from "lucide-react";
+import { Scale, Download, CloudDownload, CloudUpload } from "lucide-react";
 import { useSuperAllianceApi } from "@/lib/superallianceapi";
+import { useSuperAlliance } from "@/contexts/SuperAllianceProvider.tsx";
 import { useUser } from "@clerk/clerk-react";
 import { toast } from "sonner";
 import { useMediaQuery } from "@mantine/hooks";
@@ -81,7 +82,8 @@ const SelectionDND = ({
   });
 
   const { user } = useUser();
-  const { getTeamSelection, api } = useSuperAllianceApi();
+  const { selectedEvent } = useSuperAlliance();
+  const { getTeamSelection, saveTeamSelection, exportTeamSelection } = useSuperAllianceApi();
 
   const [columns, setColumns] = useState<any[]>(defaultCols);
   const columnsId = useMemo(() => columns.map((col) => col.id), [columns]);
@@ -90,8 +92,6 @@ const SelectionDND = ({
   const [activeColumn, setActiveColumn] = useState<Column | null>(null);
 
   const [activeTeam, setActiveTeam] = useState<Team | null>(null);
-
-  const [printMode, setPrintMode] = useState<boolean>(false);
 
   const isMobile = useMediaQuery(`(max-width: ${em(750)})`);
 
@@ -128,9 +128,9 @@ const SelectionDND = ({
   const getApiSelection = () => {
     (async function () {
       try {
-        const data = await getTeamSelection();
+        const data = await getTeamSelection(selectedEvent);
         toast.success("Team Selection retrieved successfully!");
-        const teams = data.teams;
+        const teams = data.teams || [];
         setTeams(teams);
       } catch {
         toast.error("The team selections failed to retrieve.");
@@ -140,16 +140,36 @@ const SelectionDND = ({
 
   const saveSelection = () => {
     (async function () {
-      await api
-        .post(`${import.meta.env.VITE_API_URL}/api/teamSelection/save`, {
-          teams: teams,
-        })
-        .then(function () {
-          toast.success("Team Selection saved successfully!");
-        })
-        .catch(function () {
-          toast.error("The team selections failed to save.");
-        });
+      try {
+        await saveTeamSelection(selectedEvent!, teams);
+        toast.success("Team Selection saved successfully!");
+      } catch {
+        toast.error("The team selections failed to save.");
+      }
+    })();
+  };
+
+  const exportSelection = () => {
+    (async function () {
+      try {
+        // Save current selection so we export the latest data
+        await saveTeamSelection(selectedEvent!, teams);
+        
+        // Export the saved data
+        const blob = await exportTeamSelection(selectedEvent!);
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `team-selection-${selectedEvent}-${new Date().toISOString().split('T')[0]}.csv`;
+        document.body.appendChild(a);
+        a.click();
+        window.URL.revokeObjectURL(url);
+        document.body.removeChild(a);
+        
+        toast.success("Team Selection saved and exported successfully!");
+      } catch {
+        toast.error("The team selection save/export failed.");
+      }
     })();
   };
 
@@ -159,19 +179,19 @@ const SelectionDND = ({
         {user?.publicMetadata.role == "admin"  && (
           <>
             <Button onClick={getApiSelection}>
-              <Download className={`h-4 w-4 ${isMobile ? "" : "mr-2"}`} />{" "}
-              {isMobile ? null : "Get from DB"}
+              <CloudDownload className={`h-4 w-4 ${isMobile ? "" : "mr-2"}`} />{" "}
+              {isMobile ? null : "Load"}
             </Button>
             <Button onClick={saveSelection}>
-              <Save className={`h-4 w-4 ${isMobile ? "" : "mr-2"}`} />
-              {isMobile ? null : "Save to DB"}
+              <CloudUpload className={`h-4 w-4 ${isMobile ? "" : "mr-2"}`} />
+              {isMobile ? null : "Save"}
             </Button>
             <Button
-              variant={printMode ? "secondary" : "default"}
-              onClick={() => setPrintMode(printMode ? false : true)}
+              variant={"default"}
+              onClick={exportSelection}
             >
-              <Printer className={`h-4 w-4 ${isMobile ? "" : "mr-2"}`} />
-              {isMobile ? null : "Print Mode"}
+              <Download className={`h-4 w-4 ${isMobile ? "" : "mr-2"}`} />
+              {isMobile ? null : "Export"}
             </Button>
             <Button
               variant={compareMode ? "secondary" : "default"}
@@ -183,8 +203,8 @@ const SelectionDND = ({
                 setCompareMode(compareMode ? false : true);
               }}
             >
-              <Diff className={`h-4 w-4 ${isMobile ? "" : "mr-2"}`} />
-              {isMobile ? null : "Compare Mode"}
+              <Scale className={`h-4 w-4 ${isMobile ? "" : "mr-2"}`} />
+              {isMobile ? null : "Compare"}
             </Button>
           </>
         )}
@@ -195,7 +215,7 @@ const SelectionDND = ({
         onDragEnd={onDragEnd}
         onDragOver={onDragOver}
       >
-        <BoardContainer printMode={printMode}>
+        <BoardContainer>
           <SortableContext items={columnsId}>
             {columns.map((col) => (
               <BoardColumn
@@ -204,7 +224,6 @@ const SelectionDND = ({
                 teams={teams.filter((team) => team.columnId === col.id)}
                 totalTeamCount={teams.length}
                 setSelectedTeam={setSelectedTeam}
-                printMode={printMode}
                 compareMode={compareMode}
                 leftTeam={leftTeam}
                 rightTeam={rightTeam}
@@ -226,7 +245,6 @@ const SelectionDND = ({
                   )}
                   totalTeamCount={teams.length}
                   setSelectedTeam={setSelectedTeam}
-                  printMode={printMode}
                   compareMode={compareMode}
                   leftTeam={leftTeam}
                   rightTeam={rightTeam}

--- a/app/src/components/selection/selection-dnd.tsx
+++ b/app/src/components/selection/selection-dnd.tsx
@@ -1,10 +1,15 @@
 import {
   BoardColumn,
   BoardContainer,
+  type ColumnDragData,
   type Column,
 } from "@/components/selection/selection-column";
-import { useMemo, useState } from "react";
-import { Team, TeamCard } from "@/components/selection/selection-team-card";
+import { Dispatch, SetStateAction, useMemo, useState, useRef, useEffect } from "react";
+import {
+  Team,
+  TeamCard,
+  type TeamDragData,
+} from "@/components/selection/selection-team-card";
 import {
   DndContext,
   DragEndEvent,
@@ -51,6 +56,13 @@ const defaultCols = [
 ] satisfies Column[];
 
 export type ColumnId = (typeof defaultCols)[number]["id"];
+type PendingDragData = TeamDragData | ColumnDragData;
+type PendingDragOver = {
+  activeId: UniqueIdentifier;
+  overId: UniqueIdentifier;
+  activeData: PendingDragData;
+  overData: PendingDragData;
+};
 
 const SelectionDND = ({
   teams,
@@ -63,27 +75,149 @@ const SelectionDND = ({
   setLeftTeam,
   setRightTeam,
 }: {
-  teams: any[];
-  setTeams: (teams: any[]) => void;
+  teams: Team[];
+  setTeams: Dispatch<SetStateAction<Team[]>>;
   setSelectedTeam: (teamId: UniqueIdentifier) => void;
   compareMode: boolean;
   setCompareMode: (compareMode: boolean) => void;
-  leftTeam: any;
-  rightTeam: any;
-  setLeftTeam: (leftTeam: any) => void;
-  setRightTeam: (rightTeam: any) => void;
+  leftTeam: UniqueIdentifier | null | undefined;
+  rightTeam: UniqueIdentifier | null | undefined;
+  setLeftTeam: Dispatch<SetStateAction<UniqueIdentifier | null | undefined>>;
+  setRightTeam: Dispatch<SetStateAction<UniqueIdentifier | null | undefined>>;
 }) => {
 
   const { user } = useUser();
   const { selectedEvent } = useSuperAlliance();
   const { getTeamSelection, saveTeamSelection, exportTeamSelection } = useSuperAllianceApi();
 
-  const [columns, setColumns] = useState<any[]>(defaultCols);
+  const [columns, setColumns] = useState<Column[]>(defaultCols);
   const columnsId = useMemo(() => columns.map((col) => col.id), [columns]);
 
   const [activeColumn, setActiveColumn] = useState<Column | null>(null);
   const [activeTeam, setActiveTeam] = useState<Team | null>(null);
   const isMobile = useMediaQuery(`(max-width: ${em(750)})`);
+
+  const dragOverFrameRef = useRef<number | null>(null);
+  const pendingDragOverRef = useRef<PendingDragOver | null>(null);
+
+  const applyDragOverUpdate = (
+    currentTeams: Team[],
+    pending: PendingDragOver
+  ): Team[] => {
+    const { activeId, overId, activeData, overData } = pending;
+
+    if (activeData?.type !== "Team") {
+      return currentTeams;
+    }
+
+    if (overData?.type === "Column") {
+      const activeIndex = currentTeams.findIndex((t) => t.id === activeId);
+      if (activeIndex === -1) {
+        return currentTeams;
+      }
+
+      const activeTeam = currentTeams[activeIndex];
+      if (!activeTeam || activeTeam.columnId === overId) {
+        return currentTeams;
+      }
+
+      const nextTeams = [...currentTeams];
+      nextTeams[activeIndex] = { ...activeTeam, columnId: overId as ColumnId };
+      return nextTeams;
+    }
+
+    if (overData?.type !== "Team") {
+      return currentTeams;
+    }
+
+    const activeIndex = currentTeams.findIndex((t) => t.id === activeId);
+    const overIndex = currentTeams.findIndex((t) => t.id === overId);
+
+    if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {
+      return currentTeams;
+    }
+
+    const nextTeams = [...currentTeams];
+    const activeTeam = nextTeams[activeIndex];
+    const overTeam = nextTeams[overIndex];
+
+    if (!activeTeam || !overTeam) {
+      return currentTeams;
+    }
+
+    if (activeTeam.columnId !== overTeam.columnId) {
+      nextTeams[activeIndex] = { ...activeTeam, columnId: overTeam.columnId };
+      return arrayMove(
+        nextTeams,
+        activeIndex,
+        overIndex === 0 ? overIndex : overIndex - 1
+      );
+    }
+
+    return arrayMove(nextTeams, activeIndex, overIndex);
+  };
+
+  const processPendingDragOver = () => {
+    const pending = pendingDragOverRef.current;
+    if (!pending) return;
+    pendingDragOverRef.current = null;
+    setTeams((currentTeams) => applyDragOverUpdate(currentTeams, pending));
+  };
+
+  const sortUnsortedTeams = (sortBy: "number" | "rank") => {
+    const unsortedTeams = teams.filter((team) => team.columnId === "unsorted");
+
+    if (unsortedTeams.length < 2) {
+      return;
+    }
+
+    const sortedUnsortedTeams = [...unsortedTeams].sort((a, b) => {
+      if (sortBy === "number") {
+        return Number(a.teamNumber) - Number(b.teamNumber);
+      }
+
+      const aRank = Number(a.rank);
+      const bRank = Number(b.rank);
+      const aHasRank = Number.isFinite(aRank) && aRank > 0;
+      const bHasRank = Number.isFinite(bRank) && bRank > 0;
+
+      if (aHasRank && bHasRank) {
+        return aRank - bRank;
+      }
+
+      if (aHasRank) {
+        return -1;
+      }
+
+      if (bHasRank) {
+        return 1;
+      }
+
+      return 0;
+    });
+
+    let unsortedIndex = 0;
+    setTeams(
+      teams.map((team) => {
+        if (team.columnId !== "unsorted") {
+          return team;
+        }
+
+        const nextTeam = sortedUnsortedTeams[unsortedIndex];
+        unsortedIndex += 1;
+        return nextTeam;
+      })
+    );
+  };
+
+  useEffect(() => {
+    return () => {
+      if (dragOverFrameRef.current !== null) {
+        cancelAnimationFrame(dragOverFrameRef.current);
+        dragOverFrameRef.current = null;
+      }
+    };
+  }, []);
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -199,10 +333,20 @@ const SelectionDND = ({
                 column={col}
                 teams={teams.filter((team) => team.columnId === col.id)}
                 totalTeamCount={teams.length}
+                onSortByNumber={
+                  col.id === "unsorted"
+                    ? () => sortUnsortedTeams("number")
+                    : undefined
+                }
+                onSortByRank={
+                  col.id === "unsorted"
+                    ? () => sortUnsortedTeams("rank")
+                    : undefined
+                }
                 setSelectedTeam={setSelectedTeam}
                 compareMode={compareMode}
-                leftTeam={leftTeam}
-                rightTeam={rightTeam}
+                leftTeam={leftTeam ?? undefined}
+                rightTeam={rightTeam ?? undefined}
                 setLeftTeam={setLeftTeam}
                 setRightTeam={setRightTeam}
               />
@@ -222,8 +366,8 @@ const SelectionDND = ({
                   totalTeamCount={teams.length}
                   setSelectedTeam={setSelectedTeam}
                   compareMode={compareMode}
-                  leftTeam={leftTeam}
-                  rightTeam={rightTeam}
+                  leftTeam={leftTeam ?? undefined}
+                  rightTeam={rightTeam ?? undefined}
                   setLeftTeam={setLeftTeam}
                   setRightTeam={setRightTeam}
                 />
@@ -251,6 +395,12 @@ const SelectionDND = ({
   }
 
   function onDragEnd(event: DragEndEvent) {
+    if (dragOverFrameRef.current !== null) {
+      cancelAnimationFrame(dragOverFrameRef.current);
+      dragOverFrameRef.current = null;
+    }
+    processPendingDragOver();
+
     setActiveColumn(null);
     setActiveTeam(null);
 
@@ -291,51 +441,24 @@ const SelectionDND = ({
 
     const activeData = active.data.current;
     const overData = over.data.current;
+    if (!activeData || !overData) return;
 
-    const isActiveATeam = activeData?.type === "Team";
-    const isOverATeam = overData?.type === "Team";
+    // Collect the drag over event data instead of processing immediately
+    pendingDragOverRef.current = {
+      activeId,
+      overId,
+      activeData,
+      overData,
+    };
 
-    if (!isActiveATeam) return;
-
-    // Im dropping a Team over another Team
-    if (isActiveATeam && isOverATeam) {
-      const newTeams = [...teams];
-      const activeIndex = newTeams.findIndex((t: any) => t.id === activeId);
-      const overIndex = newTeams.findIndex((t: any) => t.id === overId);
-      const activeTeam = newTeams[activeIndex];
-      const overTeam = newTeams[overIndex];
-      if (
-        activeTeam &&
-        overTeam &&
-        activeTeam.columnId !== overTeam.columnId
-      ) {
-        activeTeam.columnId = overTeam.columnId;
-        const reorderedTeams = arrayMove(
-          newTeams,
-          activeIndex,
-          overIndex == 0 ? overIndex : overIndex - 1
-        );
-        setTeams(reorderedTeams);
-        return;
-      }
-
-      const reorderedTeams = arrayMove(newTeams, activeIndex, overIndex);
-      setTeams(reorderedTeams);
+    if (dragOverFrameRef.current !== null) {
+      return;
     }
 
-    const isOverAColumn = overData?.type === "Column";
-
-    // Im dropping a Team over a column
-    if (isActiveATeam && isOverAColumn) {
-      const newTeams = [...teams];
-      const activeIndex = newTeams.findIndex((t: any) => t.id === activeId);
-      const activeTeam = newTeams[activeIndex];
-      if (activeTeam) {
-        activeTeam.columnId = overId as ColumnId;
-        const reorderedTeams = arrayMove(newTeams, activeIndex, activeIndex);
-        setTeams(reorderedTeams);
-      }
-    }
+    dragOverFrameRef.current = requestAnimationFrame(() => {
+      dragOverFrameRef.current = null;
+      processPendingDragOver();
+    });
   }
 };
 

--- a/app/src/components/selection/selection-dnd.tsx
+++ b/app/src/components/selection/selection-dnd.tsx
@@ -3,7 +3,7 @@ import {
   BoardContainer,
   type Column,
 } from "@/components/selection/selection-column";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Team, TeamCard } from "@/components/selection/selection-team-card";
 import {
   DndContext,
@@ -53,7 +53,8 @@ const defaultCols = [
 export type ColumnId = (typeof defaultCols)[number]["id"];
 
 const SelectionDND = ({
-  propTeams,
+  teams,
+  setTeams,
   setSelectedTeam,
   compareMode,
   setCompareMode,
@@ -62,7 +63,8 @@ const SelectionDND = ({
   setLeftTeam,
   setRightTeam,
 }: {
-  propTeams: any[];
+  teams: any[];
+  setTeams: (teams: any[]) => void;
   setSelectedTeam: (teamId: UniqueIdentifier) => void;
   compareMode: boolean;
   setCompareMode: (compareMode: boolean) => void;
@@ -71,15 +73,6 @@ const SelectionDND = ({
   setLeftTeam: (leftTeam: any) => void;
   setRightTeam: (rightTeam: any) => void;
 }) => {
-  const initialTeams: Team[] = propTeams.map((team: any) => {
-    return {
-      id: `${team.teamNumber}`,
-      columnId: "unsorted",
-      teamNumber: `${team.teamNumber}`,
-      teamName: `${team.teamName}`,
-      rank: `${team.teamRank}`,
-    };
-  });
 
   const { user } = useUser();
   const { selectedEvent } = useSuperAlliance();
@@ -87,27 +80,10 @@ const SelectionDND = ({
 
   const [columns, setColumns] = useState<any[]>(defaultCols);
   const columnsId = useMemo(() => columns.map((col) => col.id), [columns]);
-  const [teams, setTeams] = useState<Team[]>(initialTeams);
 
   const [activeColumn, setActiveColumn] = useState<Column | null>(null);
-
   const [activeTeam, setActiveTeam] = useState<Team | null>(null);
-
   const isMobile = useMediaQuery(`(max-width: ${em(750)})`);
-
-  useEffect(() => {
-    setTeams(
-      propTeams.map((team: any) => {
-        return {
-          id: `${team.teamNumber}`,
-          columnId: "unsorted",
-          teamNumber: `${team.teamNumber}`,
-          teamName: `${team.teamName}`,
-          rank: `${team.teamRank}`,
-        };
-      })
-    );
-  }, [propTeams]);
 
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -317,47 +293,48 @@ const SelectionDND = ({
     const overData = over.data.current;
 
     const isActiveATeam = activeData?.type === "Team";
-    const isOverATeam = activeData?.type === "Team";
+    const isOverATeam = overData?.type === "Team";
 
     if (!isActiveATeam) return;
 
     // Im dropping a Team over another Team
     if (isActiveATeam && isOverATeam) {
-      setTeams((teams) => {
-        const activeIndex = teams.findIndex((t) => t.id === activeId);
-        const overIndex = teams.findIndex((t) => t.id === overId);
-        const activeTeam = teams[activeIndex];
-        const overTeam = teams[overIndex];
-        if (
-          activeTeam &&
-          overTeam &&
-          activeTeam.columnId !== overTeam.columnId
-        ) {
-          activeTeam.columnId = overTeam.columnId;
-          return arrayMove(
-            teams,
-            activeIndex,
-            overIndex == 0 ? overIndex : overIndex - 1
-          );
-        }
+      const newTeams = [...teams];
+      const activeIndex = newTeams.findIndex((t: any) => t.id === activeId);
+      const overIndex = newTeams.findIndex((t: any) => t.id === overId);
+      const activeTeam = newTeams[activeIndex];
+      const overTeam = newTeams[overIndex];
+      if (
+        activeTeam &&
+        overTeam &&
+        activeTeam.columnId !== overTeam.columnId
+      ) {
+        activeTeam.columnId = overTeam.columnId;
+        const reorderedTeams = arrayMove(
+          newTeams,
+          activeIndex,
+          overIndex == 0 ? overIndex : overIndex - 1
+        );
+        setTeams(reorderedTeams);
+        return;
+      }
 
-        return arrayMove(teams, activeIndex, overIndex);
-      });
+      const reorderedTeams = arrayMove(newTeams, activeIndex, overIndex);
+      setTeams(reorderedTeams);
     }
 
     const isOverAColumn = overData?.type === "Column";
 
     // Im dropping a Team over a column
     if (isActiveATeam && isOverAColumn) {
-      setTeams((teams) => {
-        const activeIndex = teams.findIndex((t) => t.id === activeId);
-        const activeTeam = teams[activeIndex];
-        if (activeTeam) {
-          activeTeam.columnId = overId as ColumnId;
-          return arrayMove(teams, activeIndex, activeIndex);
-        }
-        return teams;
-      });
+      const newTeams = [...teams];
+      const activeIndex = newTeams.findIndex((t: any) => t.id === activeId);
+      const activeTeam = newTeams[activeIndex];
+      if (activeTeam) {
+        activeTeam.columnId = overId as ColumnId;
+        const reorderedTeams = arrayMove(newTeams, activeIndex, activeIndex);
+        setTeams(reorderedTeams);
+      }
     }
   }
 };

--- a/app/src/components/selection/selection-team-card.tsx
+++ b/app/src/components/selection/selection-team-card.tsx
@@ -109,8 +109,8 @@ export function TeamCard({
           : undefined,
       })}
     >
-      <CardHeader className="px-3 py-3 space-between flex flex-row border-secondary relative">
-        <span>
+      <CardHeader className="relative flex flex-row items-start gap-2 border-secondary px-3 py-3">
+        <span className="min-w-0 flex-1">
           {compareMode && (
             <>
               {leftTeam == team.id ? (
@@ -136,7 +136,7 @@ export function TeamCard({
             {team?.rank > 0 ? (
               <Badge
                 variant={"outline"}
-                className={`ml-auto font-semibold text-red-600 h-6 ${
+                className={`ml-auto h-6 shrink-0 whitespace-nowrap font-semibold text-red-600 ${
                   compareMode &&
                   (leftTeam == team.id || rightTeam == team.id) &&
                   "text-black"

--- a/app/src/components/selection/selection-team-card.tsx
+++ b/app/src/components/selection/selection-team-card.tsx
@@ -19,7 +19,6 @@ interface TeamCardProps {
   team: Team;
   isOverlay?: boolean;
   setSelectedTeam?: (teamId: UniqueIdentifier) => void;
-  printMode?: boolean;
   compareMode?: boolean;
   leftTeam?: UniqueIdentifier;
   rightTeam?: UniqueIdentifier;
@@ -38,7 +37,6 @@ export function TeamCard({
   team,
   isOverlay,
   setSelectedTeam,
-  printMode,
   compareMode,
   leftTeam,
   rightTeam,
@@ -133,7 +131,7 @@ export function TeamCard({
             {team?.teamName}
           </span>
         </span>
-        {!printMode && (
+        {(
           <>
             {team?.rank > 0 ? (
               <Badge

--- a/app/src/components/selection/selection-team-view.tsx
+++ b/app/src/components/selection/selection-team-view.tsx
@@ -32,12 +32,14 @@ const SelectionTeamView = ({
   setSelectedTeam,
   pitFormData,
   setFormsOpened,
+  moveTeamToColumn,
 }: {
   teams: any;
   aggregationData: any;
   setSelectedTeam: (teamId: UniqueIdentifier) => void;
   pitFormData: any;
   setFormsOpened: any;
+  moveTeamToColumn?: (teamId: string, columnId: string) => void;
 }) => {
   const [mainOpened, setMainOpened] = useState(false);
   const [imageOpened, setImageOpened] = useState(false);
@@ -94,6 +96,7 @@ const SelectionTeamView = ({
           setCriticalsOpened={setCriticalsOpened}
           setCommentsOpened={setCommentsOpened}
           appSettings={appSettings}
+          moveTeamToColumn={moveTeamToColumn}
         />
       </Modal>
       <Modal
@@ -197,6 +200,7 @@ export const DataDisplay = ({
   setCriticalsOpened,
   setCommentsOpened,
   appSettings,
+  moveTeamToColumn,
 }: {
   teams: any;
   aggregationData: any;
@@ -209,6 +213,7 @@ export const DataDisplay = ({
   setCriticalsOpened: any;
   setCommentsOpened: any;
   appSettings: any;
+  moveTeamToColumn?: (teamId: string, columnId: string) => void;
 }) => {
   const averages = [
     { label: "Avg Total Fuel", value: aggregationData?.avgTotalFuel },
@@ -244,6 +249,16 @@ export const DataDisplay = ({
 
   const navigate = useNavigate();
 
+  const handleMoveTeam = (columnId: string) => {
+    if (moveTeamToColumn && aggregationData?._id) {
+      moveTeamToColumn(aggregationData._id.toString(), columnId);
+    }
+  };
+
+  // Find which column this team is currently in
+  const currentTeam = teams?.find((team: any) => team.id === aggregationData?._id?.toString());
+  const currentColumnId = currentTeam?.columnId;
+
   return (
     <div>
       <div className="flex items-center justify-between space-y-2 mb-3">
@@ -267,11 +282,45 @@ export const DataDisplay = ({
         </div>
       </div>
       <Tabs defaultValue="inspector" className="space-y-4 w-[85vw]">
-        <TabsList>
-          <TabsTrigger value="inspector">Inspector</TabsTrigger>
-          <TabsTrigger value="pitform">Pit Form</TabsTrigger>
-          <TabsTrigger value="graphs">Graphs</TabsTrigger>
-        </TabsList>
+        <div className="flex items-center justify-between">
+          <TabsList>
+            <TabsTrigger value="inspector">Inspector</TabsTrigger>
+            <TabsTrigger value="pitform">Pit Form</TabsTrigger>
+            <TabsTrigger value="graphs">Graphs</TabsTrigger>
+          </TabsList>
+          
+          {/* Team Movement Buttons */}
+          {moveTeamToColumn ? (
+            <div className="flex items-center gap-2">
+              <Button
+                onClick={() => handleMoveTeam('r1')}
+                variant={currentColumnId === 'r1' ? "default" : "outline"}
+                size="sm"
+                className="h-8"
+              >
+                R1
+              </Button>
+              <Button
+                onClick={() => handleMoveTeam('r2')}
+                variant={currentColumnId === 'r2' ? "default" : "outline"}
+                size="sm"
+                className="h-8"
+              >
+                R2
+              </Button>
+              <Button
+                onClick={() => handleMoveTeam('r3')}
+                variant={currentColumnId === 'r3' ? "default" : "outline"}
+                size="sm"
+                className="h-8"
+              >
+                R3
+              </Button>
+            </div>
+          ) : (
+            <div></div>
+          )}
+        </div>
         <TabsContent
           value="inspector"
           className="space-y-4 w-[calc(100%-1rem)] h-[72vh]"

--- a/app/src/contexts/SuperAllianceProvider.tsx
+++ b/app/src/contexts/SuperAllianceProvider.tsx
@@ -61,7 +61,7 @@ export function SuperAllianceProvider(props: any) {
           setEventTeams(
             eventTeams.filter((team: any) =>
               team.teamEvent.includes(selectedEvent)
-            )
+            ).sort .sort((a: any, b: any) => parseInt(a.teamNumber) - parseInt(b.teamNumber))
           );
           if (user?.publicMetadata.role === "admin") {
             const eventForms = await getForms(selectedEvent);
@@ -103,7 +103,7 @@ export function SuperAllianceProvider(props: any) {
     (async function () {
       if (selectedEvent && selectedEvent !== "none") {
         const eventTeams = await getTeams(appConfig.year, selectedEvent);
-        setEventTeams(eventTeams);
+        setEventTeams(eventTeams.sort((a: any, b: any) => parseInt(a.teamNumber) - parseInt(b.teamNumber)));
         if (user?.publicMetadata.role === "admin") {
           const eventForms = await getForms(selectedEvent);
           setEventForms(eventForms);

--- a/app/src/lib/superallianceapi.ts
+++ b/app/src/lib/superallianceapi.ts
@@ -153,15 +153,27 @@ export function useSuperAllianceApi() {
     }
   };
 
-  const getTeamSelection = async () => {
+  const getTeamSelection = async (eventCode: string) => {
     try {
       const res = await api.get(
-        `${import.meta.env.VITE_API_URL}/api/teamSelection`
+        `${import.meta.env.VITE_API_URL}/api/teamSelection/${eventCode}`
       );
       const data = res.data;
       return data;
     } catch {
       throw new Error("Team Selection not found");
+    }
+  };
+
+  const saveTeamSelection = async (eventCode: string, teams: any[]) => {
+    try {
+      const res = await api.post(
+        `${import.meta.env.VITE_API_URL}/api/teamSelection/save/${eventCode}`,
+        { teams }
+      );
+      return res.data;
+    } catch {
+      throw new Error("Failed to save team selection");
     }
   };
 
@@ -191,6 +203,18 @@ export function useSuperAllianceApi() {
     }
   }
 
+  const exportTeamSelection = async (eventCode: string) => {
+    try {
+      const res = await api.get(
+        `${import.meta.env.VITE_API_URL}/api/teamSelection/${eventCode}/report`,
+        { responseType: 'blob' }
+      );
+      return res.data;
+    } catch {
+      throw new Error("Failed to export team selection");
+    }
+  };
+
   return {
     getForms,
     getTeams,
@@ -204,6 +228,8 @@ export function useSuperAllianceApi() {
     getBadComments,
     getAppSettings,
     getTeamSelection,
+    saveTeamSelection,
+    exportTeamSelection,
     getMatchData,
     getEventTeamRank,
     api

--- a/app/src/pages/admin/Settings.tsx
+++ b/app/src/pages/admin/Settings.tsx
@@ -6,17 +6,12 @@ import { LoadingOverlay, em } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
 import { Settings } from "lucide-react";
 import { useLocation } from "react-router-dom";
-import { useEffect } from "react";
 
 function AdminSettings() {
-  const { events, appSettings, refreshSA  } = useSuperAlliance();
+  const { events, appSettings } = useSuperAlliance();
   const pathname = useLocation().pathname;
 
   const isMobile = useMediaQuery(`(max-width: ${em(750)})`);
-
-  useEffect(() => {
-    refreshSA!.appSettings();
-  }, []);
 
   return (
     <div className="flex flex-row h-full">

--- a/app/src/pages/analysis/selection/TeamSelection.tsx
+++ b/app/src/pages/analysis/selection/TeamSelection.tsx
@@ -9,6 +9,16 @@ import { Drawer, Modal, em } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
 import { useEffect, useState } from "react";
 
+type Team = {
+  id: string;
+  columnId: string;
+  teamNumber: string;
+  teamName: string;
+  rank: string;
+};
+
+type ColumnId = "unsorted" | "r1" | "r2" | "r3";
+
 function TeamSelection() {
   const {
     selectedEvent,
@@ -25,6 +35,53 @@ function TeamSelection() {
   const [leftTeam, setLeftTeam] = useState<any>();
   const [rightTeam, setRightTeam] = useState<any>();
   const { getPitFormByTeam } = useSuperAllianceApi();
+  
+  const [teams, setTeams] = useState<Team[]>([]);
+  
+  // Initialize teams when eventTeams changes
+  useEffect(() => {
+    if (eventTeams) {
+      setTeams(
+        eventTeams.map((team: any) => ({
+          id: `${team.teamNumber}`,
+          columnId: "unsorted" as ColumnId,
+          teamNumber: `${team.teamNumber}`,
+          teamName: `${team.teamName}`,
+          rank: `${team.teamRank}`,
+        }))
+      );
+    }
+  }, [eventTeams]);
+  
+  // Function to move a team to a specific column at the top
+  const moveTeamToColumn = (teamId: string, columnId: string) => {
+    setTeams((currentTeams) => {
+      const teamIndex = currentTeams.findIndex((t) => t.id === teamId);
+      if (teamIndex === -1) return currentTeams;
+
+      const updatedTeams = [...currentTeams];
+      const teamToMove = { ...updatedTeams[teamIndex] };
+      teamToMove.columnId = columnId as ColumnId;
+      
+      // Remove from current position
+      updatedTeams.splice(teamIndex, 1);
+      
+      // Find position to insert at top of target column
+      const firstTeamInTargetColumn = updatedTeams.findIndex(
+        (t) => t.columnId === columnId
+      );
+      
+      if (firstTeamInTargetColumn === -1) {
+        // No teams in target column, add to end
+        updatedTeams.push(teamToMove);
+      } else {
+        // Insert at the beginning of target column
+        updatedTeams.splice(firstTeamInTargetColumn, 0, teamToMove);
+      }
+      
+      return updatedTeams;
+    });
+  };
 
   const isMobile = useMediaQuery(`(max-width: ${em(750)})`);
 
@@ -49,7 +106,8 @@ function TeamSelection() {
       </h1>
       <div className="h-full flex justify-center items-center w-full">
             <SelectionDND
-              propTeams={eventTeams}
+              teams={teams}
+              setTeams={setTeams}
               setSelectedTeam={setSelectedTeam}
               compareMode={compareMode}
               setCompareMode={setCompareMode}
@@ -59,7 +117,7 @@ function TeamSelection() {
               setRightTeam={setRightTeam}
             />
             <SelectionCompare
-              teams={eventTeams}
+              teams={teams}
               aggregation={eventAggregation}
               compareMode={compareMode}
               setCompareMode={setCompareMode}
@@ -67,11 +125,12 @@ function TeamSelection() {
               rightTeam={rightTeam}
               setLeftTeam={setLeftTeam}
               setRightTeam={setRightTeam}
+              moveTeamToColumn={moveTeamToColumn}
             />
             {selectedTeam !== "" && eventAggregation && (
               <>
                 <SelectionTeamView
-                  teams={eventTeams}
+                  teams={teams}
                   aggregationData={
                     eventAggregation?.filter((team: any) => {
                       return team._id == Number(selectedTeam);
@@ -80,6 +139,7 @@ function TeamSelection() {
                   setSelectedTeam={setSelectedTeam}
                   pitFormData={pitFormData}
                   setFormsOpened={setFormListOpened}
+                  moveTeamToColumn={moveTeamToColumn}
                 />
                 <Modal
                   classNames={{

--- a/app/src/pages/analysis/selection/TeamSelection.tsx
+++ b/app/src/pages/analysis/selection/TeamSelection.tsx
@@ -5,16 +5,32 @@ import SelectionDND from "@/components/selection/selection-dnd";
 import SelectionTeamView from "@/components/selection/selection-team-view";
 import { useSuperAlliance } from "@/contexts/SuperAllianceProvider";
 import { useSuperAllianceApi } from "@/lib/superallianceapi";
+import type { UniqueIdentifier } from "@dnd-kit/core";
 import { Drawer, Modal, em } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
 import { useEffect, useState } from "react";
 
 type Team = {
-  id: string;
-  columnId: string;
+  id: UniqueIdentifier;
+  columnId: ColumnId;
   teamNumber: string;
   teamName: string;
   rank: string;
+};
+
+type EventTeamPayload = {
+  teamNumber: string | number;
+  teamName?: string;
+  teamRank?: string | number | null;
+};
+
+type AggregationPayload = {
+  _id: string | number;
+};
+
+type EventFormPayload = {
+  _id: string | number;
+  teamNumber: string | number;
 };
 
 type ColumnId = "unsorted" | "r1" | "r2" | "r3";
@@ -27,13 +43,13 @@ function TeamSelection() {
     eventForms,
   } = useSuperAlliance();
   const [pitFormData, setPitFormData] = useState(null);
-  const [selectedTeam, setSelectedTeam] = useState<any>("");
-  const [selectedForm, setSelectedForm] = useState<any>("");
+  const [selectedTeam, setSelectedTeam] = useState<UniqueIdentifier | "">("");
+  const [selectedForm, setSelectedForm] = useState<string | number | "">("");
   const [formListOpened, setFormListOpened] = useState(false);
   const [formOpened, setFormOpened] = useState(false);
   const [compareMode, setCompareMode] = useState(false);
-  const [leftTeam, setLeftTeam] = useState<any>();
-  const [rightTeam, setRightTeam] = useState<any>();
+  const [leftTeam, setLeftTeam] = useState<UniqueIdentifier | null | undefined>(undefined);
+  const [rightTeam, setRightTeam] = useState<UniqueIdentifier | null | undefined>(undefined);
   const { getPitFormByTeam } = useSuperAllianceApi();
   
   const [teams, setTeams] = useState<Team[]>([]);
@@ -42,12 +58,12 @@ function TeamSelection() {
   useEffect(() => {
     if (eventTeams) {
       setTeams(
-        eventTeams.map((team: any) => ({
-          id: `${team.teamNumber}`,
-          columnId: "unsorted" as ColumnId,
-          teamNumber: `${team.teamNumber}`,
-          teamName: `${team.teamName}`,
-          rank: `${team.teamRank}`,
+        eventTeams.map((team: EventTeamPayload) => ({
+        id: `${team.teamNumber}`,
+        columnId: "unsorted" as ColumnId,
+        teamNumber: `${team.teamNumber}`,
+        teamName: `${team.teamName ?? ""}`,
+        rank: `${team.teamRank ?? ""}`,
         }))
       );
     }
@@ -89,7 +105,7 @@ function TeamSelection() {
     (async function () {
       setPitFormData(
         selectedTeam
-          ? await getPitFormByTeam(selectedEvent, selectedTeam).catch(() => null)
+          ? await getPitFormByTeam(selectedEvent, String(selectedTeam)).catch(() => null)
           : null
       );
     })();
@@ -132,7 +148,7 @@ function TeamSelection() {
                 <SelectionTeamView
                   teams={teams}
                   aggregationData={
-                    eventAggregation?.filter((team: any) => {
+                    eventAggregation?.filter((team: AggregationPayload) => {
                       return team._id == Number(selectedTeam);
                     })[0]
                   }
@@ -160,7 +176,7 @@ function TeamSelection() {
                   <FormList
                     teamsPage={false}
                     forms={eventForms?.filter(
-                      (form: any) => form.teamNumber == selectedTeam
+                      (form: EventFormPayload) => form.teamNumber == selectedTeam
                     )}
                     selectedForm={selectedForm}
                     setSelectedForm={setSelectedForm}
@@ -181,7 +197,7 @@ function TeamSelection() {
                   {selectedForm && (
                     <FormView
                       formData={
-                        eventForms.filter((form: any) => form._id == selectedForm)[0]
+                        eventForms.filter((form: EventFormPayload) => form._id == selectedForm)[0]
                       }
                     />
                   )}


### PR DESCRIPTION
### New features
- Add CSV export and remove "print mode".
- Add the ability to sort the "unsorted" column by rank or team number. This will help us build the top and bottom of our pick list, and then make it possible to locate teams by number. It might be nice to add more sorting or filtering/highlighting/chips to this column in the future.
- Add buttons to move a team to the top of a column from the detail and compare views. Highlight the button for the column it's currently in.

### Enhancements
- Save separate records for each event. This way we don't have to manually wipe the selection in the database between events.
- Store all saves in the DB so we can go back if something goes wrong. Loading just pulls the latest save.
- When sorting teams by number, use number sorting instead of text sorting so 11283 appears after 1816.

### Bug fixes
- Fix bug where changing the active event required a browser refresh to fully apply.
- Fix bug where the rank chip text would wrap.
- Fix bug where drag-n-drop would cause an infinite loop, crashing the app.